### PR TITLE
Update OHTTP Encapsulator Library and Bump Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ corresponding [server](https://github.com/cloudflare/privacy-gateway-server-go) 
 #### Declare Gradle dependencies
 ```kotlin
 dependencies {
-    implementation("com.github.flohealth:ok-ohttp-plugin:0.1.0")
+    implementation("com.github.flohealth:ok-ohttp-plugin:0.2.0")
 }
 ```
 #### Download artifacts

--- a/lib-ohttp-plugin/build.gradle.kts
+++ b/lib-ohttp-plugin/build.gradle.kts
@@ -39,7 +39,7 @@ publishing {
         publishing = this,
         config = PublishingConfig(
             artifactId = "ok-ohttp-plugin-android",
-            version = "0.1.0",
+            version = "0.2.0",
         ),
     )
     setupPublishingRepositories(publishing = this)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,7 +24,7 @@ dependencyResolutionManagement {
             // https://github.com/square/okhttp/blob/master/CHANGELOG.md
             version("okhttp", "4.10.0")
 
-            version("ohttp-encapsulator-android", "0.1.0")
+            version("ohttp-encapsulator-android", "0.2.0")
             version("bhttp", "0.1.0")
 
             library("androidGradlePlugin", "com.android.tools.build", "gradle").versionRef("androidGradlePlugin")


### PR DESCRIPTION
Why?

There is a new version of the OHTTP Encapsulator library which has the updated native library to support 16kb page alignement for Android 15+

What?

- Update the dependency
- Bump the version