### PR TITLE
Update okHttp

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ corresponding [server](https://github.com/cloudflare/privacy-gateway-server-go) 
 #### Declare Gradle dependencies
 ```kotlin
 dependencies {
-    implementation("com.github.flohealth:ok-ohttp-plugin:0.2.0")
+    implementation("com.github.flohealth:ok-ohttp-plugin:0.3.0")
 }
 ```
 #### Download artifacts

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,5 +18,5 @@ allprojects {
 }
 
 tasks.register("clean", Delete::class) {
-    delete(rootProject.buildDir)
+    delete(rootProject.layout.buildDirectory)
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 
 dependencies {
     // android gradle plugin, required by custom plugin
-    implementation("com.android.tools.build:gradle:7.4.2")
+    implementation("com.android.tools.build:gradle:9.1.1")
     // kotlin plugin, required by custom plugin
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.21")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.0")
 }

--- a/buildSrc/src/main/java/android-library-base.gradle.kts
+++ b/buildSrc/src/main/java/android-library-base.gradle.kts
@@ -1,15 +1,15 @@
+import com.android.build.api.dsl.LibraryExtension
 import health.flo.network.gradle.Environment
 import health.flo.network.gradle.configureCompiler
 import health.flo.network.gradle.configureSdk
 
 plugins {
     id("com.android.library")
-    kotlin("android")
 }
 
-android {
+extensions.configure<LibraryExtension>("android") {
     configureSdk()
-    configureCompiler(tasks, kotlinOptions)
+    configureCompiler(project.tasks)
 
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -19,12 +19,12 @@ android {
     }
 
     buildFeatures {
-        aidl = false
-        renderScript = false
         shaders = false
     }
+}
 
-    kotlinOptions {
+kotlin {
+    compilerOptions {
         allWarningsAsErrors = Environment.isCI
     }
 }

--- a/buildSrc/src/main/java/health/flo/network/gradle/CompilerConfig.kt
+++ b/buildSrc/src/main/java/health/flo/network/gradle/CompilerConfig.kt
@@ -1,38 +1,35 @@
 package health.flo.network.gradle
 
-import com.android.build.gradle.BaseExtension
+import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.dsl.CompileOptions
 import org.gradle.api.JavaVersion
 import org.gradle.api.tasks.TaskContainer
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 data class CompilerConfig(
     val javaVersion: JavaVersion,
     val jvmTarget: JvmTarget = JvmTarget.fromTarget(javaVersion.toString()),
-) {
-    val javaVersionString: String = javaVersion.toString()
-}
+)
 
 private val defaultSdkConfig = CompilerConfig(
     javaVersion = JavaVersion.VERSION_1_8,
 )
 
-fun BaseExtension.configureCompiler(
+fun CommonExtension.configureCompiler(
     taskContainer: TaskContainer,
-    kotlinOptions: KotlinJvmOptions,
     config: CompilerConfig = defaultSdkConfig,
 ) {
-    compileOptions {
-        sourceCompatibility = config.javaVersion
-        targetCompatibility = config.javaVersion
-    }
-
-    kotlinOptions.jvmTarget = config.javaVersionString
+    compileOptions.configure(config)
 
     taskContainer.withType(KotlinCompile::class.java).configureEach {
         compilerOptions {
             jvmTarget.set(config.jvmTarget)
         }
     }
+}
+
+private fun CompileOptions.configure(config: CompilerConfig) {
+    sourceCompatibility = config.javaVersion
+    targetCompatibility = config.javaVersion
 }

--- a/buildSrc/src/main/java/health/flo/network/gradle/PublishingConfig.kt
+++ b/buildSrc/src/main/java/health/flo/network/gradle/PublishingConfig.kt
@@ -1,6 +1,6 @@
 package health.flo.network.gradle
 
-import com.android.build.gradle.LibraryExtension
+import com.android.build.api.dsl.LibraryExtension
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
@@ -62,7 +62,7 @@ fun Project.setupPublishingRepositories(publishing: PublishingExtension) {
             //  ./gradlew publishReleasePublicationToMvnBuildDirRepository to publish to <module>/build/repo
             maven {
                 name = "MvnBuildDir"
-                url = uri("${project.buildDir}/repo")
+                url = layout.buildDirectory.dir("repo").get().asFile.toURI()
             }
         }
     }

--- a/buildSrc/src/main/java/health/flo/network/gradle/SdkConfig.kt
+++ b/buildSrc/src/main/java/health/flo/network/gradle/SdkConfig.kt
@@ -11,7 +11,7 @@ data class SdkConfig(
 private val defaultSdkConfig = SdkConfig(
     minSdk = 26,
     targetSdk = 31,
-    compileSdk = 33,
+    compileSdk = 37,
 )
 
 fun LibraryExtension.configureSdk(sdkConfig: SdkConfig = defaultSdkConfig) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/gradle/unit-testing.gradle.kts
+++ b/gradle/unit-testing.gradle.kts
@@ -1,10 +1,14 @@
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.getByType
+
 val testImplementation by configurations
 val testRuntimeOnly by configurations
+val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 
 dependencies {
-    testRuntimeOnly(libs.testing.junit5.engine)
+    testRuntimeOnly(libs.findLibrary("testing.junit5.engine").get())
 
-    testImplementation(libs.bundles.testing.junit5)
-    testImplementation(libs.bundles.testing.mockito)
-    testImplementation(libs.testing.assertj)
+    testImplementation(libs.findBundle("testing.junit5").get())
+    testImplementation(libs.findBundle("testing.mockito").get())
+    testImplementation(libs.findLibrary("testing.assertj").get())
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-all.zip
+distributionSha256Sum=c72fb9991f6025cbe337d52ba77e531b3faf62bdd3e348fe1ccee9f51c71adb0

--- a/lib-ohttp-plugin/build.gradle.kts
+++ b/lib-ohttp-plugin/build.gradle.kts
@@ -39,7 +39,7 @@ publishing {
         publishing = this,
         config = PublishingConfig(
             artifactId = "ok-ohttp-plugin-android",
-            version = "0.2.0",
+            version = "0.3.0",
         ),
     )
     setupPublishingRepositories(publishing = this)

--- a/lib-ohttp-plugin/src/main/java/health/flo/network/ohttp/client/config/OhttpCryptoConfigProvider.kt
+++ b/lib-ohttp-plugin/src/main/java/health/flo/network/ohttp/client/config/OhttpCryptoConfigProvider.kt
@@ -7,6 +7,7 @@ import okhttp3.Request
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
 internal interface OhttpCryptoConfigProvider {
@@ -60,6 +61,7 @@ internal class OhttpCryptoConfigProviderImpl constructor(
         }
     }
 
+    @OptIn(ExperimentalContracts::class)
     private fun isFreshConfig(
         candidate: OhttpCryptoConfig?,
         stale: OhttpCryptoConfig?,
@@ -94,10 +96,7 @@ internal class OhttpCryptoConfigProviderImpl constructor(
             .execute()
 
         return if (response.isSuccessful) {
-            val responseBody = response.body
-                ?: throw IOException("Empty OHTTP crypto config received!")
-
-            OhttpCryptoConfig(responseBody.bytes())
+            OhttpCryptoConfig(response.body.bytes())
         } else {
             throw IOException("OHTTP crypto config request failed!")
         }

--- a/lib-ohttp-plugin/src/main/java/health/flo/network/ohttp/client/interceptor/CacheLayerPacker.kt
+++ b/lib-ohttp-plugin/src/main/java/health/flo/network/ohttp/client/interceptor/CacheLayerPacker.kt
@@ -7,7 +7,6 @@ import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
-import okhttp3.internal.toHostHeader
 
 internal class CacheLayerPacker(
     private val urlEncoder: UrlEncoder,

--- a/lib-ohttp-plugin/src/main/java/health/flo/network/ohttp/client/interceptor/HostHeader.kt
+++ b/lib-ohttp-plugin/src/main/java/health/flo/network/ohttp/client/interceptor/HostHeader.kt
@@ -1,0 +1,16 @@
+package health.flo.network.ohttp.client.interceptor
+
+import okhttp3.HttpUrl
+
+internal fun HttpUrl.toHostHeader(): String {
+    val hostHeader = if (host.contains(":")) "[$host]" else host
+
+    return if (port == defaultPort(scheme)) hostHeader else "$hostHeader:$port"
+}
+
+private fun defaultPort(scheme: String): Int =
+    when (scheme) {
+        "http" -> 80
+        "https" -> 443
+        else -> -1
+    }

--- a/lib-ohttp-plugin/src/main/java/health/flo/network/ohttp/client/interceptor/OhttpPreprocessingInterceptor.kt
+++ b/lib-ohttp-plugin/src/main/java/health/flo/network/ohttp/client/interceptor/OhttpPreprocessingInterceptor.kt
@@ -37,7 +37,7 @@ internal class OhttpPreprocessingInterceptor internal constructor(
                     if (staleConfigHash != null) {
                         val recoverRequest = addRefreshConfigHeader(relayRequest, staleConfigHash)
 
-                        chainResponse.body?.close()
+                        chainResponse.body.close()
                         chain.proceed(recoverRequest)
                     } else {
                         chainResponse

--- a/lib-ohttp-plugin/src/main/java/health/flo/network/ohttp/client/interceptor/OhttpRequestProcessor.kt
+++ b/lib-ohttp-plugin/src/main/java/health/flo/network/ohttp/client/interceptor/OhttpRequestProcessor.kt
@@ -15,7 +15,6 @@ import health.flo.network.ohttp.client.relay.OhttpRelayCallUnpacker
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
-import okhttp3.internal.toHostHeader
 import java.net.HttpURLConnection.HTTP_OK
 import java.net.HttpURLConnection.HTTP_UNAUTHORIZED
 

--- a/lib-ohttp-plugin/src/main/java/health/flo/network/ohttp/client/relay/OhttpRelayCallPacker.kt
+++ b/lib-ohttp-plugin/src/main/java/health/flo/network/ohttp/client/relay/OhttpRelayCallPacker.kt
@@ -39,9 +39,6 @@ internal class OhttpRelayCallUnpacker(
 ) {
 
     fun unwrapFromOhttp(response: Response): Response {
-        val responseBody = response.body
-            ?: throw IOException("Empty OHTTP response body")
-
         val headers = response.headers(CONTENT_TYPE_HEADER)
         val isOhttpResponse = headers.contains(OHTTP_RESPONSE_CONTENT_TYPE_HEADER_VALUE)
 
@@ -51,7 +48,7 @@ internal class OhttpRelayCallUnpacker(
 
         val encryptedResponse = OhttpEncryptedResponse(
             protocol = response.protocol,
-            data = responseBody.bytes(),
+            data = response.body.bytes(),
         )
 
         return decryptor.decrypt(encryptedResponse)

--- a/lib-ohttp-plugin/src/test/java/health/flo/network/ohttp/client/OhttpStackIntegrationTest.kt
+++ b/lib-ohttp-plugin/src/test/java/health/flo/network/ohttp/client/OhttpStackIntegrationTest.kt
@@ -14,6 +14,7 @@ import health.flo.network.ohttp.client.HttpHeaders.HOST_HEADER
 import health.flo.network.ohttp.client.HttpHeaders.OHTTP_REQUEST_CONTENT_TYPE_HEADER_VALUE
 import health.flo.network.ohttp.client.HttpHeaders.OHTTP_RESPONSE_CONTENT_TYPE_HEADER_VALUE
 import health.flo.network.ohttp.client.HttpHeaders.USER_AGENT_HEADER
+import health.flo.network.ohttp.client.interceptor.toHostHeader
 import health.flo.network.ohttp.client.utils.UrlEncoder
 import health.flo.network.ohttp.encapsulator.DecapsulationResult
 import health.flo.network.ohttp.encapsulator.EncapsulationResult
@@ -27,9 +28,6 @@ import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
-import okhttp3.internal.http2.Header
-import okhttp3.internal.toHeaderList
-import okhttp3.internal.toHostHeader
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
@@ -132,7 +130,7 @@ internal class OhttpStackIntegrationTest {
         val recordedRequest: RecordedRequest = targetServer.takeRequestWithTimeout()
 
         assertThat(recordedRequest.headers.sorted())
-            .contains(Header(MARKER_HEADER, USER_CONTENT_MARKER))
+            .contains("$MARKER_HEADER: $USER_CONTENT_MARKER")
     }
 
     @Test
@@ -157,7 +155,7 @@ internal class OhttpStackIntegrationTest {
         relayServer.enqueue(stubValidRelayResponse())
 
         val response = sut.newCall(request).execute()
-        val responseBodyBytes = response.body!!.bytes()
+        val responseBodyBytes = response.body.bytes()
         val recordedRequest: RecordedRequest = relayServer.takeRequestWithTimeout()
 
         verify(okHttpBinarySerializer).serialize(
@@ -633,7 +631,7 @@ internal class OhttpStackIntegrationTest {
 }
 
 private fun Response.alsoReadBodyToTriggerResponseCaching(): Response {
-    this.body!!.bytes()
+    this.body.bytes()
     return this
 }
 
@@ -643,8 +641,10 @@ private fun stubValidRelayResponse(): MockResponse {
         .setBody("body with OHTTP-encrypted response from target server")
 }
 
-private fun Headers.sorted(): List<Header> {
-    return this.toHeaderList().sortedBy(Header::toString)
+private fun Headers.sorted(): List<String> {
+    return (0 until size)
+        .map { index -> "${name(index)}: ${value(index)}" }
+        .sorted()
 }
 
 private fun MockWebServer.takeRequestWithTimeout(): RecordedRequest {

--- a/lib-ohttp-plugin/src/test/java/health/flo/network/ohttp/client/config/OhttpCryptoConfigProviderImplTest.kt
+++ b/lib-ohttp-plugin/src/test/java/health/flo/network/ohttp/client/config/OhttpCryptoConfigProviderImplTest.kt
@@ -45,15 +45,6 @@ internal class OhttpCryptoConfigProviderImplTest {
     )
 
     @Test
-    fun `getConfig should throw IOException when crypto config request received with empty body`() {
-        okhttpClientResponse.stub { on { this.body } doReturn null }
-
-        assertThrows<IOException> {
-            sut.getConfig()
-        }
-    }
-
-    @Test
     fun `getConfig should throw IOException when crypto config request was unsuccessful`() {
         okhttpClientResponse.stub { on { this.isSuccessful } doReturn false }
 

--- a/lib-ohttp-plugin/src/test/java/health/flo/network/ohttp/client/interceptor/CacheLayerPackerTest.kt
+++ b/lib-ohttp-plugin/src/test/java/health/flo/network/ohttp/client/interceptor/CacheLayerPackerTest.kt
@@ -9,7 +9,6 @@ import health.flo.network.ohttp.client.utils.UrlEncoder
 import health.flo.test.extensions.toDynamicTests
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
-import okhttp3.internal.toHostHeader
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.Test

--- a/lib-ohttp-plugin/src/test/java/health/flo/network/ohttp/client/interceptor/OhttpRequestProcessorTest.kt
+++ b/lib-ohttp-plugin/src/test/java/health/flo/network/ohttp/client/interceptor/OhttpRequestProcessorTest.kt
@@ -20,7 +20,6 @@ import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.TlsVersion.TLS_1_3
-import okhttp3.internal.toHostHeader
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows

--- a/lib-ohttp-plugin/src/test/java/health/flo/network/ohttp/client/relay/OhttpRelayCallPackerTest.kt
+++ b/lib-ohttp-plugin/src/test/java/health/flo/network/ohttp/client/relay/OhttpRelayCallPackerTest.kt
@@ -85,19 +85,6 @@ internal class OhttpRelayCallPackerTest {
     }
 
     @Test
-    fun `unwrapFromOhttp should throw IOException when response body is empty`() {
-        val response = stubResponse.newBuilder()
-            .addHeader(CONTENT_TYPE_HEADER, OHTTP_RESPONSE_CONTENT_TYPE_HEADER_VALUE)
-            .build()
-
-        val (_, unpacker) = sut.wrapToOhttp(request, cryptoConfig)
-
-        assertThrows<IOException> {
-            unpacker.unwrapFromOhttp(response)
-        }
-    }
-
-    @Test
     fun `unwrapFromOhttp should throw IOException when proper Content-Type header is not found`() {
         val response = stubResponse.newBuilder()
             .body("Encrypted Response Body".toResponseBody())

--- a/lib-ohttp-plugin/src/test/java/health/flo/network/ohttp/client/relay/OhttpRelayCallUnpackerTest.kt
+++ b/lib-ohttp-plugin/src/test/java/health/flo/network/ohttp/client/relay/OhttpRelayCallUnpackerTest.kt
@@ -61,17 +61,6 @@ internal class OhttpRelayCallUnpackerTest {
     }
 
     @Test
-    fun `unwrapFromOhttp should throw IOException when response body is null`() {
-        responseWithEncryptedBody.stub {
-            on { this.body } doReturn null
-        }
-
-        assertThrows<IOException> {
-            sut.unwrapFromOhttp(responseWithEncryptedBody)
-        }
-    }
-
-    @Test
     fun `unwrapFromOhttp should throw IOException when response has wrong Content-Type`() {
         responseWithEncryptedBody.stub {
             on { this.headers(CONTENT_TYPE_HEADER) } doReturn listOf("WRONG Content-Type")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,16 +5,16 @@ dependencyResolutionManagement {
             version("assertj", "3.24.2")
             // https://developer.android.com/studio/releases/gradle-plugin
             // Please update Lint version whenever you update Android Gradle plugin
-            version("androidGradlePlugin", "7.4.2")
+            version("androidGradlePlugin", "9.1.1")
 
             // https://github.com/mannodermaus/android-junit5/releases
-            version("androidJunit5", "1.9.3.0")
+            version("androidJunit5", "1.14.0.0")
 
             // https://junit.org/junit5/docs/snapshot/release-notes/
             version("junit5", "5.9.2")
 
             // https://kotlinlang.org/docs/releases.html#release-details
-            version("kotlin", "1.8.21")
+            version("kotlin", "2.3.0")
 
             // https://github.com/mockito/mockito/releases
             version("mockito", "4.11.0")
@@ -22,7 +22,7 @@ dependencyResolutionManagement {
             version("mockitoKotlin", "4.1.0")
 
             // https://github.com/square/okhttp/blob/master/CHANGELOG.md
-            version("okhttp", "4.12.0")
+            version("okhttp", "5.3.2")
 
             version("ohttp-encapsulator-android", "0.2.0")
             version("bhttp", "0.1.0")
@@ -63,7 +63,7 @@ dependencyResolutionManagement {
 }
 
 plugins {
-    id("com.gradle.enterprise").version("3.12.3")
+    id("com.gradle.enterprise").version("3.13.1")
 }
 
 include(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,7 +22,7 @@ dependencyResolutionManagement {
             version("mockitoKotlin", "4.1.0")
 
             // https://github.com/square/okhttp/blob/master/CHANGELOG.md
-            version("okhttp", "4.10.0")
+            version("okhttp", "5.3.2")
 
             version("ohttp-encapsulator-android", "0.2.0")
             version("bhttp", "0.1.0")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,7 +22,7 @@ dependencyResolutionManagement {
             version("mockitoKotlin", "4.1.0")
 
             // https://github.com/square/okhttp/blob/master/CHANGELOG.md
-            version("okhttp", "5.3.2")
+            version("okhttp", "4.12.0")
 
             version("ohttp-encapsulator-android", "0.2.0")
             version("bhttp", "0.1.0")


### PR DESCRIPTION
Key changes:

- OkHttp 5.3.2
- Kotlin 2.3.0
- AGP 9.1.1
- Gradle wrapper 9.5.1
- compileSdk 37
- artifact/README version 0.3.0
- added android.useAndroidX=true
- replaced OkHttp internal toHostHeader() usage with a local helper
- updated tests for OkHttp 5’s non-null Response.body